### PR TITLE
Implement save/load support

### DIFF
--- a/grasshopper_mcp/bridge.py
+++ b/grasshopper_mcp/bridge.py
@@ -148,8 +148,14 @@ def save_document(path: str):
     params = {
         "path": path
     }
-    
-    return send_to_grasshopper("save_document", params)
+
+    response = send_to_grasshopper("save_document", params)
+
+    if not response.get("success", False):
+        error_msg = response.get("error") or response.get("message", "Unknown error")
+        raise RuntimeError(f"Failed to save document: {error_msg}")
+
+    return response.get("result") or response.get("data") or response
 
 @server.tool("load_document")
 def load_document(path: str):
@@ -165,8 +171,14 @@ def load_document(path: str):
     params = {
         "path": path
     }
-    
-    return send_to_grasshopper("load_document", params)
+
+    response = send_to_grasshopper("load_document", params)
+
+    if not response.get("success", False):
+        error_msg = response.get("error") or response.get("message", "Unknown error")
+        raise RuntimeError(f"Failed to load document: {error_msg}")
+
+    return response.get("result") or response.get("data") or response
 
 @server.tool("get_document_info")
 def get_document_info():


### PR DESCRIPTION
## Summary
- implement saving & loading Grasshopper docs in `DocumentCommandHandler` using `GH_DocumentIO`
- run save/load on the UI thread and return success/error info
- surface errors for save/load functions in `bridge.py`

## Testing
- `python -m py_compile grasshopper_mcp/bridge.py`


------
https://chatgpt.com/codex/tasks/task_e_687ffe0fe9088333b71bb52008bd87de