### PR TITLE
Add set_component_value tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ The system consists of the following parts:
 
 5. **Start Using Grasshopper with Claude Desktop**
 
-   You can now use Claude Desktop to control Grasshopper through natural language commands.
+   You can now use Claude Desktop to control Grasshopper through natural language commands. The bridge exposes tools like `add_component`, `connect_components`, and `set_component_value` for programmatic control.
 
 ## Example Commands
 
@@ -131,6 +131,7 @@ Here are some example commands you can use with Claude Desktop:
 - "Connect the circle to a extrude component with a height of 10"
 - "Create a grid of points with 5 rows and 5 columns"
 - "Apply a random rotation to all selected objects"
+- "Update the value of a Number Slider using `set_component_value`"
 
 ## Troubleshooting
 

--- a/grasshopper_mcp/bridge.py
+++ b/grasshopper_mcp/bridge.py
@@ -354,6 +354,28 @@ def get_component_info(component_id: str):
     
     return result
 
+@server.tool("set_component_value")
+def set_component_value(component_id: str, value: str):
+    """
+    Set the value of a Grasshopper component.
+
+    This can update panel text, slider values or the first input of a
+    component by forwarding the request to the Grasshopper MCP server.
+
+    Args:
+        component_id: ID of the component to update
+        value: New value as a string
+
+    Returns:
+        Result returned by Grasshopper after applying the value
+    """
+    params = {
+        "id": component_id,
+        "value": value
+    }
+
+    return send_to_grasshopper("set_component_value", params)
+
 @server.tool("get_all_components")
 def get_all_components():
     """


### PR DESCRIPTION
## Summary
- implement `set_component_value` tool in `bridge.py`
- mention available tools including new one in usage instructions
- add example for using `set_component_value`

## Testing
- `python -m py_compile grasshopper_mcp/bridge.py`


------
https://chatgpt.com/codex/tasks/task_e_6880020f43408333b6b70abdb85255ba