### PR TITLE
Add delete and move component commands

### DIFF
--- a/GH_MCP/GH_MCP/Commands/GrasshopperCommandRegistry.cs
+++ b/GH_MCP/GH_MCP/Commands/GrasshopperCommandRegistry.cs
@@ -65,9 +65,15 @@ namespace GH_MCP.Commands
             
             // 設置組件值
             RegisterCommand("set_component_value", ComponentCommandHandler.SetComponentValue);
-            
+
             // 獲取組件信息
             RegisterCommand("get_component_info", ComponentCommandHandler.GetComponentInfo);
+
+            // 刪除組件
+            RegisterCommand("delete_component", ComponentCommandHandler.DeleteComponent);
+
+            // 移動組件
+            RegisterCommand("move_component", ComponentCommandHandler.MoveComponent);
         }
 
         /// <summary>

--- a/grasshopper_mcp/bridge.py
+++ b/grasshopper_mcp/bridge.py
@@ -126,8 +126,28 @@ def add_component(component_type: str, x: float, y: float):
         "x": x,
         "y": y
     }
-    
+
     return send_to_grasshopper("add_component", params)
+
+@server.tool("delete_component")
+def delete_component(component_id: str):
+    """Delete a component from the Grasshopper canvas"""
+    params = {
+        "id": component_id
+    }
+
+    return send_to_grasshopper("delete_component", params)
+
+@server.tool("move_component")
+def move_component(component_id: str, x: float, y: float):
+    """Move an existing component to a new canvas location"""
+    params = {
+        "id": component_id,
+        "x": x,
+        "y": y
+    }
+
+    return send_to_grasshopper("move_component", params)
 
 @server.tool("clear_document")
 def clear_document():


### PR DESCRIPTION
## Summary
- implement new `DeleteComponent` and `MoveComponent` handlers in the plugin
- register the commands in `GrasshopperCommandRegistry`
- expose `delete_component` and `move_component` tools in the Python bridge

## Testing
- `python -m py_compile grasshopper_mcp/__init__.py grasshopper_mcp/bridge.py setup.py`
- `dotnet build GH_MCP/GH_MCP.sln` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6880022551ec8333aa21c20f322bf6a5