### PR TITLE
Add utility commands and bridge tools

### DIFF
--- a/GH_MCP/GH_MCP/Commands/GrasshopperCommandRegistry.cs
+++ b/GH_MCP/GH_MCP/Commands/GrasshopperCommandRegistry.cs
@@ -24,16 +24,19 @@ namespace GH_MCP.Commands
         {
             // 註冊幾何命令
             RegisterGeometryCommands();
-            
+
             // 註冊組件命令
             RegisterComponentCommands();
-            
+
             // 註冊文檔命令
             RegisterDocumentCommands();
-            
+
             // 註冊意圖命令
             RegisterIntentCommands();
-            
+
+            // 註冊工具命令
+            RegisterUtilityCommands();
+
             RhinoApp.WriteLine("GH_MCP: Command registry initialized.");
         }
 
@@ -101,11 +104,26 @@ namespace GH_MCP.Commands
         {
             // 創建模式
             RegisterCommand("create_pattern", IntentCommandHandler.CreatePattern);
-            
+
             // 獲取可用模式
             RegisterCommand("get_available_patterns", IntentCommandHandler.GetAvailablePatterns);
-            
+
             RhinoApp.WriteLine("GH_MCP: Intent commands registered.");
+        }
+
+        /// <summary>
+        /// 註冊工具命令
+        /// </summary>
+        private static void RegisterUtilityCommands()
+        {
+            RegisterCommand("execute_preview", UtilityCommandHandler.ExecutePreview);
+            RegisterCommand("execute_script", UtilityCommandHandler.ExecuteScript);
+            RegisterCommand("create_macro", UtilityCommandHandler.CreateMacro);
+            RegisterCommand("run_macro", UtilityCommandHandler.RunMacro);
+            RegisterCommand("snapshot", UtilityCommandHandler.Snapshot);
+            RegisterCommand("revert_snapshot", UtilityCommandHandler.RevertSnapshot);
+            RegisterCommand("get_geometry", UtilityCommandHandler.GetGeometry);
+            RegisterCommand("run_gh_python", UtilityCommandHandler.RunGHPython);
         }
 
         /// <summary>

--- a/GH_MCP/GH_MCP/Commands/UtilityCommandHandler.cs
+++ b/GH_MCP/GH_MCP/Commands/UtilityCommandHandler.cs
@@ -1,0 +1,225 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Threading;
+using GrasshopperMCP.Models;
+using Grasshopper.Kernel;
+using Rhino;
+using Rhino.Runtime;
+
+namespace GrasshopperMCP.Commands
+{
+    /// <summary>
+    /// Miscellaneous utility command handlers
+    /// </summary>
+    public static class UtilityCommandHandler
+    {
+        private static readonly Dictionary<string, string> MacroStore = new Dictionary<string, string>();
+        private static readonly Dictionary<string, string> Snapshots = new Dictionary<string, string>();
+
+        /// <summary>
+        /// Execute a new solution to refresh preview
+        /// </summary>
+        public static object ExecutePreview(Command command)
+        {
+            object result = null;
+            Exception exception = null;
+            RhinoApp.InvokeOnUiThread(new Action(() =>
+            {
+                try
+                {
+                    var doc = Grasshopper.Instances.ActiveCanvas?.Document;
+                    if (doc == null)
+                        throw new InvalidOperationException("No active Grasshopper document");
+                    doc.NewSolution(false);
+                    result = new { success = true };
+                }
+                catch (Exception ex)
+                {
+                    exception = ex;
+                    RhinoApp.WriteLine($"Error in ExecutePreview: {ex.Message}");
+                }
+            }));
+            while (result == null && exception == null)
+                Thread.Sleep(10);
+            if (exception != null)
+                throw exception;
+            return result;
+        }
+
+        /// <summary>
+        /// Execute a Rhino script string
+        /// </summary>
+        public static object ExecuteScript(Command command)
+        {
+            string script = command.GetParameter<string>("script");
+            if (string.IsNullOrEmpty(script))
+                throw new ArgumentException("Script text is required");
+            bool ok = RhinoApp.RunScript(script, false);
+            return new { success = ok };
+        }
+
+        /// <summary>
+        /// Store a Rhino command macro
+        /// </summary>
+        public static object CreateMacro(Command command)
+        {
+            string name = command.GetParameter<string>("name");
+            string macro = command.GetParameter<string>("macro");
+            if (string.IsNullOrEmpty(name) || string.IsNullOrEmpty(macro))
+                throw new ArgumentException("Name and macro are required");
+            MacroStore[name] = macro;
+            return new { success = true, name };
+        }
+
+        /// <summary>
+        /// Run a stored Rhino command macro
+        /// </summary>
+        public static object RunMacro(Command command)
+        {
+            string name = command.GetParameter<string>("name");
+            string macro = command.GetParameter<string>("macro");
+            if (!string.IsNullOrEmpty(name) && MacroStore.TryGetValue(name, out var stored))
+                macro = stored;
+            if (string.IsNullOrEmpty(macro))
+                throw new ArgumentException("Macro not found");
+            bool ok = RhinoApp.RunScript(macro, false);
+            return new { success = ok };
+        }
+
+        /// <summary>
+        /// Take a snapshot of the current document
+        /// </summary>
+        public static object Snapshot(Command command)
+        {
+            string name = command.GetParameter<string>("name") ?? Guid.NewGuid().ToString();
+            object result = null;
+            Exception exception = null;
+            RhinoApp.InvokeOnUiThread(new Action(() =>
+            {
+                try
+                {
+                    var doc = Grasshopper.Instances.ActiveCanvas?.Document;
+                    if (doc == null)
+                        throw new InvalidOperationException("No active Grasshopper document");
+                    var io = new GH_DocumentIO(doc);
+                    string path = Path.GetTempFileName();
+                    if (!io.Save(path))
+                        throw new InvalidOperationException("Failed to save snapshot");
+                    Snapshots[name] = path;
+                    result = new { success = true, name };
+                }
+                catch (Exception ex)
+                {
+                    exception = ex;
+                    RhinoApp.WriteLine($"Error in Snapshot: {ex.Message}");
+                }
+            }));
+            while (result == null && exception == null)
+                Thread.Sleep(10);
+            if (exception != null)
+                throw exception;
+            return result;
+        }
+
+        /// <summary>
+        /// Revert to a previously taken snapshot
+        /// </summary>
+        public static object RevertSnapshot(Command command)
+        {
+            string name = command.GetParameter<string>("name");
+            if (string.IsNullOrEmpty(name) || !Snapshots.TryGetValue(name, out var path))
+                throw new ArgumentException("Snapshot not found");
+            object result = null;
+            Exception exception = null;
+            RhinoApp.InvokeOnUiThread(new Action(() =>
+            {
+                try
+                {
+                    var io = new GH_DocumentIO();
+                    if (!io.Open(path) || io.Document == null)
+                        throw new InvalidOperationException("Failed to load snapshot");
+                    var canvas = Grasshopper.Instances.ActiveCanvas;
+                    if (canvas == null)
+                        throw new InvalidOperationException("No active Grasshopper canvas");
+                    canvas.Document = io.Document;
+                    canvas.Document.NewSolution(false);
+                    result = new { success = true, name };
+                }
+                catch (Exception ex)
+                {
+                    exception = ex;
+                    RhinoApp.WriteLine($"Error in RevertSnapshot: {ex.Message}");
+                }
+            }));
+            while (result == null && exception == null)
+                Thread.Sleep(10);
+            if (exception != null)
+                throw exception;
+            return result;
+        }
+
+        /// <summary>
+        /// Get preview geometry from a component
+        /// </summary>
+        public static object GetGeometry(Command command)
+        {
+            string idStr = command.GetParameter<string>("id");
+            if (string.IsNullOrEmpty(idStr))
+                throw new ArgumentException("Component ID is required");
+            object result = null;
+            Exception exception = null;
+            RhinoApp.InvokeOnUiThread(new Action(() =>
+            {
+                try
+                {
+                    var doc = Grasshopper.Instances.ActiveCanvas?.Document;
+                    if (doc == null)
+                        throw new InvalidOperationException("No active Grasshopper document");
+                    if (!Guid.TryParse(idStr, out var id))
+                        throw new ArgumentException("Invalid component ID format");
+                    var obj = doc.FindObject(id, true) as IGH_Component;
+                    if (obj == null)
+                        throw new ArgumentException("Component not found");
+                    var outputs = new List<object>();
+                    foreach (var param in obj.Params.Output)
+                    {
+                        var data = new List<string>();
+                        foreach (var d in param.VolatileData.AllData(true))
+                        {
+                            var val = d.ScriptVariable();
+                            data.Add(val != null ? val.ToString() : d.ToString());
+                        }
+                        outputs.Add(new { name = param.Name, data });
+                    }
+                    result = new { id = idStr, outputs };
+                }
+                catch (Exception ex)
+                {
+                    exception = ex;
+                    RhinoApp.WriteLine($"Error in GetGeometry: {ex.Message}");
+                }
+            }));
+            while (result == null && exception == null)
+                Thread.Sleep(10);
+            if (exception != null)
+                throw exception;
+            return result;
+        }
+
+        /// <summary>
+        /// Run a Python script inside Rhino
+        /// </summary>
+        public static object RunGHPython(Command command)
+        {
+            string script = command.GetParameter<string>("script");
+            if (string.IsNullOrEmpty(script))
+                throw new ArgumentException("Python script is required");
+            using (var py = PythonScript.Create())
+            {
+                py.ExecuteScript(script);
+            }
+            return new { success = true };
+        }
+    }
+}

--- a/grasshopper_mcp/bridge.py
+++ b/grasshopper_mcp/bridge.py
@@ -575,8 +575,61 @@ def validate_connection(source_id: str, target_id: str, source_param: str = None
         
     if target_param is not None:
         params["targetParam"] = target_param
-    
+
     return send_to_grasshopper("validate_connection", params)
+
+@server.tool("execute_preview")
+def execute_preview():
+    """Force a new solution preview in Grasshopper"""
+    return send_to_grasshopper("execute_preview")
+
+@server.tool("execute_script")
+def execute_script(script: str):
+    """Execute a Rhino command script"""
+    params = {"script": script}
+    return send_to_grasshopper("execute_script", params)
+
+@server.tool("create_macro")
+def create_macro(name: str, macro: str):
+    """Store a named Rhino macro"""
+    params = {"name": name, "macro": macro}
+    return send_to_grasshopper("create_macro", params)
+
+@server.tool("run_macro")
+def run_macro(name: str = None, macro: str = None):
+    """Run a stored or inline Rhino macro"""
+    params = {}
+    if name is not None:
+        params["name"] = name
+    if macro is not None:
+        params["macro"] = macro
+    return send_to_grasshopper("run_macro", params)
+
+@server.tool("snapshot")
+def snapshot(name: str = None):
+    """Create a snapshot of the current document"""
+    params = {}
+    if name is not None:
+        params["name"] = name
+    return send_to_grasshopper("snapshot", params)
+
+@server.tool("revert_snapshot")
+def revert_snapshot(name: str):
+    """Revert to a previously created snapshot"""
+    params = {"name": name}
+    return send_to_grasshopper("revert_snapshot", params)
+
+@server.tool("get_geometry")
+def get_geometry(component_id: str):
+    """Get preview geometry data for a component"""
+    params = {"id": component_id}
+    return send_to_grasshopper("get_geometry", params)
+
+@server.tool("run_gh_python")
+def run_gh_python(script: str):
+    """Execute Python script inside Rhino"""
+    params = {"script": script}
+    return send_to_grasshopper("run_gh_python", params)
 
 # 註冊 MCP 資源
 @server.resource("grasshopper://status")


### PR DESCRIPTION
## Summary
- implement UtilityCommandHandler with preview, script, macro, snapshot and geometry helpers
- register new commands in GrasshopperCommandRegistry
- expose matching JSON‑RPC tools in bridge.py

## Testing
- `python -m py_compile grasshopper_mcp/bridge.py`


------
https://chatgpt.com/codex/tasks/task_e_68800ec689f8833399f6b8b666f417a0